### PR TITLE
Create datasets inputs validators

### DIFF
--- a/src/validation/datasets/createDatasetInputValidator.ts
+++ b/src/validation/datasets/createDatasetInputValidator.ts
@@ -1,0 +1,16 @@
+import { validator } from 'npm:hono/validator'
+import schemaParser from "../../helpers/schemaParser.ts";
+import { ParsedFormValue } from "npm:hono/types";
+import datasetSchema from "./datasetSchema.ts";
+
+export const createDatasetInputSchema = datasetSchema.strict();
+
+const createDatasetInputValidator = validator('form', (value, c) => {
+    return schemaParser<typeof createDatasetInputSchema.shape, ParsedFormValue | ParsedFormValue[]>(
+        c,
+        createDatasetInputSchema,
+        value
+    );
+})
+
+export default createDatasetInputValidator;

--- a/src/validation/datasets/datasetSchema.ts
+++ b/src/validation/datasets/datasetSchema.ts
@@ -1,0 +1,22 @@
+import { z } from "npm:zod@3";
+import { supportedDatasetFileTypes } from "../../constant/supportedFileTypes.ts";
+import agentIdValidator from "../agents/agentIdValidator.ts";
+
+const datasetFileValidator = z
+    .instanceof(File)
+    .refine((file) => file.size && file.name, { message: "Invalid file" })
+    .refine(
+        (file) => supportedDatasetFileTypes.some((extention) => file.type.endsWith(extention)),
+        (file) => ({
+            message: `Not supported file type '${file.type}', The supported types are: ${supportedDatasetFileTypes.join(', ')}`
+        })
+    )
+
+const datasetSchema = z.object({
+    title: z.string().max(70),
+    description: z.string().max(150),
+    agentId: agentIdValidator,
+    datasetFile: datasetFileValidator,
+})
+
+export default datasetSchema

--- a/src/validation/datasets/updateDatasetInputValidator.ts
+++ b/src/validation/datasets/updateDatasetInputValidator.ts
@@ -1,0 +1,20 @@
+import { z } from 'npm:zod'
+import { validator } from 'npm:hono/validator'
+import schemaParser from "../../helpers/schemaParser.ts";
+import { ParsedFormValue } from "npm:hono/types";
+import datasetSchema from "./datasetSchema.ts";
+
+export const updateDatasetInputSchema = z.object({
+    title: datasetSchema.shape.title.optional(),
+    description: datasetSchema.shape.description.optional(),
+}).strict();
+
+const updateDatasetInputValidator = validator('json', (value, c) => {
+    return schemaParser<typeof updateDatasetInputSchema.shape, ParsedFormValue | ParsedFormValue[]>(
+        c,
+        updateDatasetInputSchema,
+        value
+    );
+})
+
+export default updateDatasetInputValidator;


### PR DESCRIPTION
Create the middlewares that handle validating the inputs coming from create and update datasets requests.