### PR TITLE
Create auth inputs validation schema and validating middlewares

### DIFF
--- a/src/validation/auth/signInSchema.ts
+++ b/src/validation/auth/signInSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const signInSchema = z.object<Record<keyof SignInUserInput, z.ZodType>>({
+    password: z.string().min(6).max(200),
+    email: z.string().email(),
+    signingMethod: z.enum(["github", "google", "credentials"]),
+});
+
+export default signInSchema;

--- a/src/validation/auth/signInValidator.ts
+++ b/src/validation/auth/signInValidator.ts
@@ -1,0 +1,13 @@
+import { validator } from 'hono/validator'
+import schemaParser from "../../helpers/schemaParser.ts";
+import signInSchema from "./signInSchema.ts";
+
+const signInValidator = validator('json', (value, c) => {
+    return schemaParser<typeof signInSchema.shape>(
+        c,
+        signInSchema,
+        value
+    );
+})
+
+export default signInValidator;

--- a/src/validation/auth/signUpValidator.ts
+++ b/src/validation/auth/signUpValidator.ts
@@ -1,0 +1,22 @@
+import { validator } from 'hono/validator'
+import schemaParser from "../../helpers/schemaParser.ts";
+import { z } from "zod";
+import signInSchema from "./signInSchema.ts";
+
+const signUpSchema = z.object<Record<keyof SignUpUserInput, z.ZodType>>({
+    password: signInSchema.shape.password,
+    email: signInSchema.shape.email,
+    signingMethod: signInSchema.shape.signingMethod,
+    username: z.string().min(3).max(70),
+    avatar: z.string().url().optional(),
+})
+
+const signUpValidator = validator('json', (value, c) => {
+    return schemaParser<typeof signUpSchema.shape>(
+        c,
+        signUpSchema,
+        value
+    );
+})
+
+export default signUpValidator;


### PR DESCRIPTION
This pull request creates the schema (`signInSchema`) that is used to validate users inputs when sign in / sign up processes, 

And creates the two middleware functions that handle the actual validation using `signInSchema`, `hono/validator` 
and `schemaParser` helper function.
